### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ nfcapd -T all -l /data -S 1 -w -z -p 9999
 version: '3.7'
 services:
   collector:
-      image: netsage/nfdump-collector:1.6.18-centos-8
+      image: netsage/nfdump-collector:1.6.18
       command: /usr/local/bin/nfcapd -T all -l /data -S 1 -w -z -p 9999
       ports:
         - "9999:9999/udp"


### PR DESCRIPTION
The tag in the redme file is was not correct:
```shell
$ docker pull netsage/nfdump-collector:1.6.18-centos-8
Error response from daemon: manifest for netsage/nfdump-collector:1.6.18-centos-8 not found: manifest unknown: manifest unknown
```
This one is:
```shell
$ docker pull netsage/nfdump-collector:1.6.18
1.6.18: Pulling from netsage/nfdump-collector
Digest: sha256:3a6e3bcf658afc8a98009f2c7d8f05d138bd8983c4f92b55fedaffb02c287709
Status: Image is up to date for netsage/nfdump-collector:1.6.18
docker.io/netsage/nfdump-collector:1.6.18
```